### PR TITLE
fix: update prediction argument to avoid lightning warning #95

### DIFF
--- a/quaterion/train/cache_mixin.py
+++ b/quaterion/train/cache_mixin.py
@@ -265,7 +265,7 @@ class CacheMixin:
                 cache_encoders,
             ),
             [cache_train_dataloader, cache_val_dataloader],
-            return_predictions=False,
+            return_predictions=True,
         )
 
     @classmethod


### PR DESCRIPTION
I haven't tested it on cars, but on `test_cache_dataloader`.
