### PR TITLE
Bump PyTorch Lightning to v1.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["framework", "similarity-learning", "metric-learning", "similarity",
 [tool.poetry.dependencies]
 python = ">=3.7,<3.10"
 torch = ">=1.8.2"
-pytorch-lightning = "^1.5.8"
+pytorch-lightning = "^1.6.4"
 quaterion-models = ">=0.1.9"
 loguru = "^0.5.3"
 mmh3 = "^3.0.0"


### PR DESCRIPTION
Closes #151 

The current minimum version for Pytorch Lightning dependency is v1.5.8. However, latest changes do not work with that version.
