### PR TITLE
update PL.Trainer flags

### DIFF
--- a/examples/train_cifar100.py
+++ b/examples/train_cifar100.py
@@ -133,7 +133,8 @@ if __name__ == "__main__":
     train_dataloader = get_dataloader()
 
     trainer = pl.Trainer(
-        gpus=1 if torch.cuda.is_available() else 0, num_nodes=1, max_epochs=10
+        accelerator="auto",
+        devices=1, num_nodes=1, max_epochs=10
     )
 
     Quaterion.fit(

--- a/examples/train_cifar100_with_pytorch_metric_learning.py
+++ b/examples/train_cifar100_with_pytorch_metric_learning.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     train_dataloader = get_dataloader()
 
     trainer = pl.Trainer(
-        gpus=1 if torch.cuda.is_available() else 0, num_nodes=1, max_epochs=10
+        accelerator="auto", devices=1, num_nodes=1, max_epochs=10
     )
 
     Quaterion.fit(

--- a/examples/train_startup_search.py
+++ b/examples/train_startup_search.py
@@ -141,7 +141,7 @@ model = Model(num_groups=dataset.get_num_industries(), lr=3e-5)
 
 train_dataloader = GroupSimilarityDataLoader(dataset, batch_size=64, shuffle=True)
 
-trainer = pl.Trainer(gpus=1, num_nodes=1, max_epochs=30)
+trainer = pl.Trainer(accelerator="auto", devices=1, num_nodes=1, max_epochs=30)
 
 Quaterion.fit(
     trainable_model=model,


### PR DESCRIPTION
[PL.Trainer](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-flags) has been revamped in the latest release and the recommended way to set cuda is using `accelerator="GPU"`.

In this PR, I have set `accelerator="auto"` which will automatically select GPU whenever available.