### PR TITLE
gitignore tochvision home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ lightning_logs/
 
 # pkl files
 *.pkl
+
+# dataset and model downloads
+torchvision/


### PR DESCRIPTION
We need to gitignore `torchvision` directory because running the cars example creates it in the repository to avoid messing up with the user home.
