### PR TITLE
fix torch==1.13.0 installation on macosx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ keywords = ["framework", "similarity-learning", "metric-learning", "similarity",
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-torch = ">=1.8.2"
+torch = [
+    {version = ">=1.8.2", markers = "sys_platform != 'darwin'"},
+    {version = ">=1.8.2,<1.13.0", markers = "sys_platform == 'darwin'"}  # crashes on torch==1.13.0, tries to install nvidia modules
+]
 pytorch-lightning = "^1.6.4"
 quaterion-models = "0.1.17"
 loguru = "^0.5.3"


### PR DESCRIPTION
`poetry` can't install `quaterion` with `torch==1.13.0` on macos x, downgrading `torch` to `1.12.1` fixes the issue.

Fails to install the following modules:
 • nvidia-cublas-cu11 (11.10.3.66)
 • nvidia-cuda-nvrtc-cu11 (11.7.99)
 • nvidia-cuda-runtime-cu11 (11.7.99)
 • nvidia-cudnn-cu11 (8.5.0.96) 