### PR TITLE
update the deprecated torch.norm with torch.linalg.norm

### DIFF
--- a/quaterion/loss/arcface_loss.py
+++ b/quaterion/loss/arcface_loss.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import LongTensor, Tensor
+from torch import linalg as LA
 
 from quaterion.loss.group_loss import GroupLoss
 
@@ -18,7 +19,7 @@ def l2_norm(inputs: torch.Tensor, dim: int = 0) -> torch.Tensor:
     Returns:
         torch.Tensor: L2-normalized tensor
     """
-    outputs = inputs / torch.norm(inputs, 2, dim, True)
+    outputs = inputs / LA.norm(inputs, 2, dim, True)
 
     return outputs
 


### PR DESCRIPTION
Solved the issue mentioned in #203 by replacing the torch.norm which will be deprecated in future versions of PyTorch with torch.linalg.norm
