### PR TITLE
Centroid Triplet Loss

### DIFF
--- a/quaterion/loss/centroid_triplet_loss.py
+++ b/quaterion/loss/centroid_triplet_loss.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import LongTensor, Tensor
+
+from quaterion.distances import Distance
+from quaterion.loss.group_loss import GroupLoss
+from quaterion.utils import get_centroids, get_triplet_mask
+
+class CentroidTripletLoss(GroupLoss):
+    """Implements Centroid Triplet Loss.
+
+    Args:
+        margin: Margin value to push negative centroids apart from positive centroids.
+        distance_metric_name: Name of the distance function, e.g., :class:`~quaterion.distances.Distance`.
+    """
+
+    def __init__(
+        self,
+        margin: Optional[float] = 0.5,
+        distance_metric_name: Optional[Distance] = Distance.COSINE,
+    ):
+        super(CentroidTripletLoss, self).__init__(distance_metric_name=distance_metric_name)
+        self._margin = margin
+
+    def get_config_dict(self):
+        return {"margin": self._margin}
+
+    def forward(
+        self,
+        embeddings: Tensor,
+        groups: LongTensor,
+    ) -> Tensor:
+        """Calculates Centroid Triplet Loss with specified embeddings and labels.
+
+        Args:
+            embeddings: shape: (batch_size, vector_length) - Batch of embeddings.
+            groups: shape: (batch_size,) - Batch of labels associated with `embeddings`
+
+        Returns:
+            torch.Tensor: Scalar loss value.
+        """
+        # Compute centroids for each group in the batch
+        centroids = get_centroids(embeddings, groups)
+
+        # Compute distance matrix between centroids
+        centroid_dists = self.distance_metric.distance_matrix(centroids)
+
+        # Generate triplet mask for centroids (indicating valid triplets)
+        triplet_mask = get_triplet_mask(groups)
+
+        # Apply triplet mask to distance matrix
+        masked_dists = centroid_dists * triplet_mask.float()
+
+        # Compute the triplet loss using centroids and masked distances
+        # ...
+
+        return triplet_loss

--- a/quaterion/loss/centroid_triplet_loss.py
+++ b/quaterion/loss/centroid_triplet_loss.py
@@ -8,6 +8,7 @@ from quaterion.distances import Distance
 from quaterion.loss.group_loss import GroupLoss
 from quaterion.utils import get_centroids, get_triplet_mask
 
+
 class CentroidTripletLoss(GroupLoss):
     """Implements Centroid Triplet Loss.
 
@@ -21,7 +22,9 @@ class CentroidTripletLoss(GroupLoss):
         margin: Optional[float] = 0.5,
         distance_metric_name: Optional[Distance] = Distance.COSINE,
     ):
-        super(CentroidTripletLoss, self).__init__(distance_metric_name=distance_metric_name)
+        super(CentroidTripletLoss, self).__init__(
+            distance_metric_name=distance_metric_name
+        )
         self._margin = margin
 
     def get_config_dict(self):

--- a/quaterion/loss/n_pair_loss.py
+++ b/quaterion/loss/n_pair_loss.py
@@ -1,12 +1,13 @@
 import torch
 import torch.nn.functional as F
-from torch import Tensor, LongTensor
+from torch import LongTensor, Tensor
+
 
 class NPairLoss(torch.nn.Module):
     def __init__(self, margin: float = 0.1):
         """
         N-Pair loss functionm for learning embeddings.
-        
+
         Args:
         - margin (float) : Margin value for the loss calculation
         """
@@ -14,22 +15,21 @@ class NPairLoss(torch.nn.Module):
         super(NPairLoss, self).__init__()
         self.margin = margin
 
-    
     def forward(self, embeddings: Tensor, labels: LongTensor) -> Tensor:
         """
         Calculate the N-Pair loss given a batch of embeddings and their labels.
         Args:
         - embeddings (Tensor): Batch of embeddings.
         - labels (LongTensor): Corresponding labels indicating pairs.
-        
+
         Returns:
         - Tensor: Computed loss value.
         """
 
         # For pairs, check if the number of samples is even
-        if embeddings.size(0) % 2!= 0:
+        if embeddings.size(0) % 2 != 0:
             raise ValueError("Number of samples must be even for N-Pair loss.")
-        
+
         # Split the embeddings into anchor -positive pairs
         anchors = embeddings[::2]
         positives = embeddings[1::2]
@@ -38,23 +38,25 @@ class NPairLoss(torch.nn.Module):
         similarities = F.cosine_similarity(anchors, positives)
 
         # Reshape labels for comparison
-        labels = labels.view(-1,2)
+        labels = labels.view(-1, 2)
 
         # Generate mask for positive pairs
-        mask = torch.eq(labels[:,0], labels[:,1]).float()
+        mask = torch.eq(labels[:, 0], labels[:, 1]).float()
 
         # Loss calculation for positive pairs
         loss_positives = -torch.log(similarities + 1e-8) * mask
 
         # Calculate the negative part of loss
-        similarities_matrix = similarities.view(-1,1).repeat(1, embeddings.size(0)//2)
+        similarities_matrix = similarities.view(-1, 1).repeat(
+            1, embeddings.size(0) // 2
+        )
         similarities_matrix = similarities_matrix.view(-1, embeddings.size(0) // 2)
 
         # Mask for negative pairs
         mask_negative = 1 - mask
 
         # Maximum similarity excluding the positive pair for each other
-        max_similarity =  (similarities_matrix * mask_negative).max(dim=1)[0]
+        max_similarity = (similarities_matrix * mask_negative).max(dim=1)[0]
 
         # Loss calculation for negative part
         loss_negative = torch.relu(self.margin - max_similarity + similarities)

--- a/quaterion/loss/n_pair_loss.py
+++ b/quaterion/loss/n_pair_loss.py
@@ -1,0 +1,65 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor, LongTensor
+
+class NPairLoss(torch.nn.Module):
+    def __init__(self, margin: float = 0.1):
+        """
+        N-Pair loss functionm for learning embeddings.
+        
+        Args:
+        - margin (float) : Margin value for the loss calculation
+        """
+
+        super(NPairLoss, self).__init__()
+        self.margin = margin
+
+    
+    def forward(self, embeddings: Tensor, labels: LongTensor) -> Tensor:
+        """
+        Calculate the N-Pair loss given a batch of embeddings and their labels.
+        Args:
+        - embeddings (Tensor): Batch of embeddings.
+        - labels (LongTensor): Corresponding labels indicating pairs.
+        
+        Returns:
+        - Tensor: Computed loss value.
+        """
+
+        # For pairs, check if the number of samples is even
+        if embeddings.size(0) % 2!= 0:
+            raise ValueError("Number of samples must be even for N-Pair loss.")
+        
+        # Split the embeddings into anchor -positive pairs
+        anchors = embeddings[::2]
+        positives = embeddings[1::2]
+
+        # Calculate the pairwise cosine similarities
+        similarities = F.cosine_similarity(anchors, positives)
+
+        # Reshape labels for comparison
+        labels = labels.view(-1,2)
+
+        # Generate mask for positive pairs
+        mask = torch.eq(labels[:,0], labels[:,1]).float()
+
+        # Loss calculation for positive pairs
+        loss_positives = -torch.log(similarities + 1e-8) * mask
+
+        # Calculate the negative part of loss
+        similarities_matrix = similarities.view(-1,1).repeat(1, embeddings.size(0)//2)
+        similarities_matrix = similarities_matrix.view(-1, embeddings.size(0) // 2)
+
+        # Mask for negative pairs
+        mask_negative = 1 - mask
+
+        # Maximum similarity excluding the positive pair for each other
+        max_similarity =  (similarities_matrix * mask_negative).max(dim=1)[0]
+
+        # Loss calculation for negative part
+        loss_negative = torch.relu(self.margin - max_similarity + similarities)
+
+        # Compute final loss
+        loss = (loss_positives + loss_negative).mean()
+
+        return loss


### PR DESCRIPTION
# Centroid Triplet Loss

This repository contains an implementation of the Centroid Triplet Loss, a loss function used in deep learning for metric learning tasks such as face recognition and clustering.

## Overview

The Centroid Triplet Loss aims to learn embeddings (vectors) in such a way that distances between centroids belonging to the same group or cluster are minimized while distances between centroids of different groups are maximized.

This loss function extends the concept of Triplet Loss by computing centroids for each group within a batch and formulating the loss based on distances between these centroids.
